### PR TITLE
fix: Preview packages to openapi

### DIFF
--- a/pipeline/generate-preview-csharp-calcvalues-package.yaml
+++ b/pipeline/generate-preview-csharp-calcvalues-package.yaml
@@ -33,15 +33,16 @@ spec:
       cd ./registry
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SWAG_PATH=$(find /workspace/source -type f -name "openapi.json")
-      if test $SWAG_PATH ; then
+      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
+      if test OPENAPI_PATH ; then
         echo OpenAPI docs found in repository
+        DOC_PATH=$OPENAPI_PATH
       else
-        SWAG_PATH=http://$(cat ../pod_ip)/openapi.json
+        DOC_PATH=http://$(cat ../pod_ip)/openapi.json
         echo OpenAPI docs not found in repository, using staging
       fi
       
-      /CreateCsharpPackage.sh $SWAG_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
+      /CreateCsharpPackage.sh $DOC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
     workingDir: /workspace/source
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace

--- a/pipeline/generate-preview-csharp-package.yaml
+++ b/pipeline/generate-preview-csharp-package.yaml
@@ -34,14 +34,19 @@ spec:
       export PREVIEW_TIMESTAMP=$(date +%s)
       
       SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
+      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
       if test $SWAG_PATH ; then
         echo Swagger docs found in repository
+        DOC_PATH=$SWAG_PATH
+      elif test $OPENAPI_PATH ; then
+        echo OpenAPI docs found in repository
+        DOC_PATH=$OPENAPI_PATH
       else
         SWAG_PATH=http://$(cat ../pod_ip)/swagger.json
         echo Swagger docs not found in repository, using staging
       fi
       
-      /CreateCsharpPackage.sh $SWAG_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
+      /CreateCsharpPackage.sh $DOC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
     workingDir: /workspace/source
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace

--- a/pipeline/generate-preview-java-package-v3.yaml
+++ b/pipeline/generate-preview-java-package-v3.yaml
@@ -34,14 +34,19 @@ spec:
         export PREVIEW_TIMESTAMP=$(date +%s)
       
         SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
+        OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
         if test $SWAG_PATH ; then
           echo Swagger docs found in repository
+          DOC_PATH=$SWAG_PATH
+        elif test $OPENAPI_PATH ; then
+          echo OpenAPI docs found in repository
+          DOC_PATH=$OPENAPI_PATH
         else
-          SWAG_PATH=http://$(cat ../pod_ip):5000/swagger/v1/swagger.json
+          DOC_PATH=http://$(cat ../pod_ip):5000/swagger/v1/swagger.json
           echo Swagger docs not found in repository, using staging
         fi
         
-        /CreateJavaPackage.sh $SWAG_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
+        /CreateJavaPackage.sh $DOC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
       workingDir: /workspace/source
   workspaces:
     - description: The git repo will be cloned onto the volume backing this workspace

--- a/pipeline/generate-preview-package-v3.yaml
+++ b/pipeline/generate-preview-package-v3.yaml
@@ -34,14 +34,19 @@ spec:
       yarn global add @openapitools/openapi-generator-cli
       
       SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
+      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
       if test $SWAG_PATH ; then
         echo Swagger docs found in repository
+        DOC_PATH=$SWAG_PATH
+      elif test $OPENAPI_PATH ; then
+        echo OpenAPI docs found in repository
+        DOC_PATH=$OPENAPI_PATH
       else
         SWAG_PATH=http://$(cat ./pod_ip):5000/swagger/v1/swagger.json
         echo Swagger docs not found in repository, using staging
       fi
       
-      /CreateAngularPackageV3.sh $SWAG_PATH
+      /CreateAngularPackageV3.sh $DOC_PATH
     workingDir: /workspace/source
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace


### PR DESCRIPTION
please check that you think this will work, I havent tampered with the default solution:

ELSE:
using the pod ip go and get an old swagger.json

So from what i can tell im just checking for openapi.json aswell as swagger.json

This will let us generate preview packages for all the python repos - not just calculated values