### PR TITLE
refactor: use script to locate openAPI spec and general tidy

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -23,8 +23,10 @@ ADD CreateAngularPackageV2.sh CreateAngularPackageV2.sh
 ADD CreateAngularPackageV3.sh CreateAngularPackageV3.sh
 ADD CreateCsharpPackage.sh CreateCsharpPackage.sh
 ADD CreateJavaPackage.sh CreateJavaPackage.sh
+ADD FindOpenAPISpec.sh FindOpenAPISpec.sh
 
 RUN chmod +x CreateAngularPackageV2.sh \
     && chmod +x CreateAngularPackageV3.sh \
     && chmod +x CreateCsharpPackage.sh \
-    && chmod +x CreateJavaPackage.sh
+    && chmod +x CreateJavaPackage.sh \
+    && chmod +x FindOpenAPISpec.sh

--- a/FindOpenAPISpec.sh
+++ b/FindOpenAPISpec.sh
@@ -4,16 +4,16 @@
 # If none is found, return the default path
 DEFAULT_PATH=$1
 
-SWAG_PATH=$(find . -type f -name "swagger.json")
-OPENAPI_PATH=$(find . -type f -name "openapi.json")
+SWAG_PATH=$(find ~+ -type f -name "swagger.json")
+OPENAPI_PATH=$(find ~+ -type f -name "openapi.json")
 if test "$SWAG_PATH" ; then
-  echo "Swagger specification found at $SWAG_PATH"
+  >&2 echo "Swagger specification found at $SWAG_PATH"
   SPEC_PATH=$SWAG_PATH
 elif test "$OPENAPI_PATH" ; then
-  echo "OpenAPI specification found at $OPENAPI_PATH"
+  >&2 echo "OpenAPI specification found at $OPENAPI_PATH"
   SPEC_PATH=$OPENAPI_PATH
 else
-  echo "Specification not found in repository using $DEFAULT_PATH"
+  >&2 echo "Specification not found in repository using $DEFAULT_PATH"
   SPEC_PATH=$DEFAULT_PATH
 fi
 

--- a/FindOpenAPISpec.sh
+++ b/FindOpenAPISpec.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-# Find the spec file from the current directory and all subdirectories
+# Finds the spec file from the current directory and all subdirectories
 # If none is found, return the default path
 DEFAULT_PATH=$1
 

--- a/FindOpenAPISpec.sh
+++ b/FindOpenAPISpec.sh
@@ -6,15 +6,15 @@ DEFAULT_PATH=$1
 
 SWAG_PATH=$(find . -type f -name "swagger.json")
 OPENAPI_PATH=$(find . -type f -name "openapi.json")
-if test $SWAG_PATH ; then
-  echo "Swagger specification found in repository"
-  DOC_PATH=$SWAG_PATH
-elif test $OPENAPI_PATH ; then
-  echo "OpenAPI specification found in repository"
-  DOC_PATH=$OPENAPI_PATH
+if test "$SWAG_PATH" ; then
+  echo "Swagger specification found at $SWAG_PATH"
+  SPEC_PATH=$SWAG_PATH
+elif test "$OPENAPI_PATH" ; then
+  echo "OpenAPI specification found at $OPENAPI_PATH"
+  SPEC_PATH=$OPENAPI_PATH
 else
   echo "Specification not found in repository using $DEFAULT_PATH"
-  DOC_PATH=$DEFAULT_PATH
+  SPEC_PATH=$DEFAULT_PATH
 fi
 
-echo $DOC_PATH
+echo "$SPEC_PATH"

--- a/FindOpenAPISpec.sh
+++ b/FindOpenAPISpec.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Find the spec file from the current directory and all subdirectories
+# If none is found, return the default path
+DEFAULT_PATH=$1
+
+SWAG_PATH=$(find . -type f -name "swagger.json")
+OPENAPI_PATH=$(find . -type f -name "openapi.json")
+if test $SWAG_PATH ; then
+  echo "Swagger specification found in repository"
+  DOC_PATH=$SWAG_PATH
+elif test $OPENAPI_PATH ; then
+  echo "OpenAPI specification found in repository"
+  DOC_PATH=$OPENAPI_PATH
+else
+  echo "Specification not found in repository using $DEFAULT_PATH"
+  DOC_PATH=$DEFAULT_PATH
+fi
+
+echo $DOC_PATH

--- a/pipeline/generate-csharp-package-nonapigw.yaml
+++ b/pipeline/generate-csharp-package-nonapigw.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: set-version-csharp
@@ -22,30 +23,16 @@ spec:
       #!/usr/bin/env sh
       . /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: csharp-swagger
     resources: {}
     script: |
       #!/bin/bash
       source /workspace/source/.jx/variables.sh
+
+      SPEC_PATH=$(/FindOpenAPISpec.sh $SwaggerUrl)
       cd ./registry
-      
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      DOC_PATH=$SwaggerUrl
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-        DOC_PATH=$SWAG_PATH
-      elif test $OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        echo Docs not found in repository, using staging
-      fi
-      
-      /CreateCsharpPackage.sh $DOC_PATH $VERSION Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
-    workingDir: /workspace/source
+      /CreateCsharpPackage.sh $SPEC_PATH $VERSION Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:
   - description: Swagger generation will occur on the staging url once it has been built.
     mountPath: /workspace

--- a/pipeline/generate-csharp-package.yaml
+++ b/pipeline/generate-csharp-package.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: set-version-csharp
@@ -22,30 +23,16 @@ spec:
       #!/usr/bin/env sh
       . /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: csharp-swagger
     resources: {}
     script: |
       #!/bin/bash
       source /workspace/source/.jx/variables.sh
+      
+      SPEC_PATH=$(/FindOpenAPISpec.sh https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName)
       cd ./registry
-      
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      DOC_PATH=https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-        DOC_PATH=$SWAG_PATH
-      elif test $OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        echo Docs not found in repository, using staging
-      fi
-      
-      /CreateCsharpPackage.sh $DOC_PATH $VERSION Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
-    workingDir: /workspace/source
+      /CreateCsharpPackage.sh $SPEC_PATH $VERSION Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:
   - description: Swagger generation will occur on the staging url once it has been built.
     mountPath: /workspace

--- a/pipeline/generate-java-package-v3.yaml
+++ b/pipeline/generate-java-package-v3.yaml
@@ -14,6 +14,7 @@ spec:
           optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
     - image: ghcr.io/jenkins-x/jx-promote:0.0.234
       name: set-version-java
@@ -22,30 +23,16 @@ spec:
         #!/usr/bin/env sh
         . /workspace/source/.jx/variables.sh
         sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-      workingDir: /workspace/source
     - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.4.3
       name: java-swagger
       resources: {}
       script: |
         #!/bin/bash
         source /workspace/source/.jx/variables.sh
-        cd ./registry
 
-        SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-        OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-        DOC_PATH=https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName
-        if test $SWAG_PATH ; then
-          echo Swagger docs found in repository
-          DOC_PATH=$SWAG_PATH
-        elif test $OPENAPI_PATH ; then
-          echo OpenAPI docs found in repository
-          DOC_PATH=$OPENAPI_PATH
-        else
-          echo Docs not found in repository, using staging
-        fi
-        
-        /CreateJavaPackage.sh $DOC_PATH $VERSION mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
-      workingDir: /workspace/source
+        SPEC_PATH=$(/FindOpenAPISpec.sh https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName)
+        cd ./registry
+        /CreateJavaPackage.sh $SPEC_PATH $VERSION mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
   workspaces:
     - description: The git repo will be cloned onto the volume backing this workspace
       mountPath: /workspace

--- a/pipeline/generate-package-v3.yaml
+++ b/pipeline/generate-package-v3.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: set-version
@@ -22,7 +23,6 @@ spec:
       #!/usr/bin/env sh
       . /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.2.9
     name: moves-like-swagger
     resources: {}
@@ -31,21 +31,8 @@ spec:
       . /workspace/source/.jx/variables.sh
       yarn global add @openapitools/openapi-generator-cli
       
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      DOC_PATH=https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-        DOC_PATH=$SWAG_PATH
-      elif test $OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        echo Docs not found in repository, using staging
-      fi
-      
-      /CreateAngularPackageV3.sh $DOC_PATH
-    workingDir: /workspace/source
+      SPEC_PATH=$(/FindOpenAPISpec.sh https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName)
+      /CreateAngularPackageV3.sh $SPEC_PATH
   workspaces:
   - description: Swagger generation will occur on the staging url once it has been built.
     mountPath: /workspace

--- a/pipeline/generate-package.yaml
+++ b/pipeline/generate-package.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: set-version-typescript
@@ -22,30 +23,16 @@ spec:
       #!/usr/bin/env sh
       source /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: moves-like-swagger
     resources: {}
     script: |
       #!/usr/bin/env sh
       source /workspace/source/.jx/variables.sh
+      
+      SPEC_PATH=$(/FindOpenAPISpec.sh https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName)
       cd ./registry
-      
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      DOC_PATH=https://api-staging.jx.mqube.build/swagger/docs/v1/$SwaggerServiceName
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-        DOC_PATH=$SWAG_PATH
-      elif test $OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        echo Docs not found in repository, using staging
-      fi
-      
-      /CreateAngularPackageV2.sh $DOC_PATH
-    workingDir: /workspace/source
+      /CreateAngularPackageV2.sh $SPEC_PATH
   workspaces:
   - description: Swagger generation will occur on the staging url once it has been built.
     mountPath: /workspace

--- a/pipeline/generate-preview-csharp-calcvalues-package.yaml
+++ b/pipeline/generate-preview-csharp-calcvalues-package.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: get-pod-ip-csharp
@@ -23,27 +24,17 @@ spec:
       . /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-ring-financial-group-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: csharp-swagger
     resources: {}
     script: |
       #!/bin/bash
       source /workspace/source/.jx/variables.sh
-      cd ./registry
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      if test OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        DOC_PATH=http://$(cat ../pod_ip)/openapi.json
-        echo OpenAPI docs not found in repository, using staging
-      fi
-      
-      /CreateCsharpPackage.sh $DOC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
-    workingDir: /workspace/source
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip)/openapi.json)
+      cd ./registry
+      /CreateCsharpPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-csharp-calcvalues-package.yaml
+++ b/pipeline/generate-preview-csharp-calcvalues-package.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)"/openapi.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)"/openapi.json)
       cd ./registry
       /CreateCsharpPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-csharp-calcvalues-package.yaml
+++ b/pipeline/generate-preview-csharp-calcvalues-package.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip)/openapi.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)"/openapi.json)
       cd ./registry
       /CreateCsharpPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-csharp-package.yaml
+++ b/pipeline/generate-preview-csharp-package.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip)/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)"/swagger.json)
       cd ./registry
       /CreateCsharpPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-csharp-package.yaml
+++ b/pipeline/generate-preview-csharp-package.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: get-pod-ip-csharp
@@ -23,31 +24,17 @@ spec:
       . /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: csharp-swagger
     resources: {}
     script: |
       #!/bin/bash
       source /workspace/source/.jx/variables.sh
-      cd ./registry
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-        DOC_PATH=$SWAG_PATH
-      elif test $OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        DOC_PATH=http://$(cat ../pod_ip)/swagger.json
-        echo Swagger docs not found in repository, using staging
-      fi
-      
-      /CreateCsharpPackage.sh $DOC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
-    workingDir: /workspace/source
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip)/swagger.json)
+      cd ./registry
+      /CreateCsharpPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-csharp-package.yaml
+++ b/pipeline/generate-preview-csharp-package.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)"/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)"/swagger.json)
       cd ./registry
       /CreateCsharpPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-golang-csharp-package.yaml
+++ b/pipeline/generate-preview-golang-csharp-package.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip):5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)":5000/swagger/v1/swagger.json)
       cd ./registry
       /CreateCsharpPackage.sh $SPEC_PATH 0.1.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-golang-csharp-package.yaml
+++ b/pipeline/generate-preview-golang-csharp-package.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)":5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)":5000/swagger/v1/swagger.json)
       cd ./registry
       /CreateCsharpPackage.sh $SPEC_PATH 0.1.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-golang-csharp-package.yaml
+++ b/pipeline/generate-preview-golang-csharp-package.yaml
@@ -14,6 +14,7 @@ spec:
         optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
   - image: ghcr.io/jenkins-x/jx-promote:0.0.234
     name: get-pod-ip-csharp
@@ -23,26 +24,17 @@ spec:
       . /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: csharp-swagger
     resources: {}
     script: |
       #!/bin/bash
       source /workspace/source/.jx/variables.sh
-      cd ./registry
       export PREVIEW_TIMESTAMP=$(date +%s)
       
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-      else
-        SWAG_PATH=http://$(cat ../pod_ip):5000/swagger/v1/swagger.json
-        echo Swagger docs not found in repository, using staging
-      fi
-      
-      /CreateCsharpPackage.sh $SWAG_PATH 0.1.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
-    workingDir: /workspace/source
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip):5000/swagger/v1/swagger.json)
+      cd ./registry
+      /CreateCsharpPackage.sh $SPEC_PATH 0.1.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP Mqube.$SwaggerServiceName.Client $REPO_OWNER $REPO_NAME
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-golang-package-v3.yaml
+++ b/pipeline/generate-preview-golang-package-v3.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       yarn global add @openapitools/openapi-generator-cli
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ./pod_ip):5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)":5000/swagger/v1/swagger.json)
       /CreateAngularPackageV3.sh $SPEC_PATH
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace

--- a/pipeline/generate-preview-golang-package-v3.yaml
+++ b/pipeline/generate-preview-golang-package-v3.yaml
@@ -24,7 +24,6 @@ spec:
       source /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.8
     name: moves-like-swagger
     resources: {}
@@ -33,16 +32,8 @@ spec:
       source /workspace/source/.jx/variables.sh
       yarn global add @openapitools/openapi-generator-cli
       
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-      else
-        SWAG_PATH=http://$(cat ./pod_ip):5000/swagger/v1/swagger.json
-        echo Swagger docs not found in repository, using staging
-      fi
-      
-      /CreateAngularPackageV3.sh $SWAG_PATH
-    workingDir: /workspace/source
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ./pod_ip):5000/swagger/v1/swagger.json)
+      /CreateAngularPackageV3.sh $SPEC_PATH
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-java-package-v3.yaml
+++ b/pipeline/generate-preview-java-package-v3.yaml
@@ -32,7 +32,7 @@ spec:
         source /workspace/source/.jx/variables.sh
         export PREVIEW_TIMESTAMP=$(date +%s)
       
-        SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)":5000/swagger/v1/swagger.json)
+        SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)":5000/swagger/v1/swagger.json)
         cd ./registry
         /CreateJavaPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-java-package-v3.yaml
+++ b/pipeline/generate-preview-java-package-v3.yaml
@@ -14,6 +14,7 @@ spec:
           optional: true
     name: ""
     resources: {}
+    workingDir: /workspace/source
   steps:
     - image: ghcr.io/jenkins-x/jx-promote:0.0.234
       name: get-pod-ip-java
@@ -23,31 +24,17 @@ spec:
         . /workspace/source/.jx/variables.sh
         echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
         sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-      workingDir: /workspace/source
     - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.4.3
       name: java-swagger
       resources: {}
       script: |
         #!/bin/bash
         source /workspace/source/.jx/variables.sh
-        cd ./registry
         export PREVIEW_TIMESTAMP=$(date +%s)
       
-        SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-        OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-        if test $SWAG_PATH ; then
-          echo Swagger docs found in repository
-          DOC_PATH=$SWAG_PATH
-        elif test $OPENAPI_PATH ; then
-          echo OpenAPI docs found in repository
-          DOC_PATH=$OPENAPI_PATH
-        else
-          DOC_PATH=http://$(cat ../pod_ip):5000/swagger/v1/swagger.json
-          echo Swagger docs not found in repository, using staging
-        fi
-        
-        /CreateJavaPackage.sh $DOC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
-      workingDir: /workspace/source
+        SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip):5000/swagger/v1/swagger.json)
+        cd ./registry
+        /CreateJavaPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
   workspaces:
     - description: The git repo will be cloned onto the volume backing this workspace
       mountPath: /workspace

--- a/pipeline/generate-preview-java-package-v3.yaml
+++ b/pipeline/generate-preview-java-package-v3.yaml
@@ -32,7 +32,7 @@ spec:
         source /workspace/source/.jx/variables.sh
         export PREVIEW_TIMESTAMP=$(date +%s)
       
-        SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip):5000/swagger/v1/swagger.json)
+        SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)":5000/swagger/v1/swagger.json)
         cd ./registry
         /CreateJavaPackage.sh $SPEC_PATH 0.0.$PULL_NUMBER-preview-$PREVIEW_TIMESTAMP mqube.${SwaggerServiceName,} $REPO_OWNER $REPO_NAME
   workspaces:

--- a/pipeline/generate-preview-package-v3.yaml
+++ b/pipeline/generate-preview-package-v3.yaml
@@ -24,7 +24,6 @@ spec:
       source /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.2.9
     name: moves-like-swagger
     resources: {}
@@ -33,21 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       yarn global add @openapitools/openapi-generator-cli
       
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      OPENAPI_PATH=$(find /workspace/source -type f -name "openapi.json")
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-        DOC_PATH=$SWAG_PATH
-      elif test $OPENAPI_PATH ; then
-        echo OpenAPI docs found in repository
-        DOC_PATH=$OPENAPI_PATH
-      else
-        DOC_PATH=http://$(cat ./pod_ip):5000/swagger/v1/swagger.json
-        echo Swagger docs not found in repository, using staging
-      fi
-      
-      /CreateAngularPackageV3.sh $DOC_PATH
-    workingDir: /workspace/source
+      /CreateAngularPackageV3.sh $(/FindOpenAPISpec.sh http://$(cat ./pod_ip):5000/swagger/v1/swagger.json)
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-package-v3.yaml
+++ b/pipeline/generate-preview-package-v3.yaml
@@ -32,7 +32,8 @@ spec:
       source /workspace/source/.jx/variables.sh
       yarn global add @openapitools/openapi-generator-cli
       
-      /CreateAngularPackageV3.sh $(/FindOpenAPISpec.sh http://$(cat ./pod_ip):5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ./pod_ip):5000/swagger/v1/swagger.json)
+      /CreateAngularPackageV3.sh $SPEC_PATH
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-package-v3.yaml
+++ b/pipeline/generate-preview-package-v3.yaml
@@ -32,7 +32,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       yarn global add @openapitools/openapi-generator-cli
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ./pod_ip):5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)":5000/swagger/v1/swagger.json)
       /CreateAngularPackageV3.sh $SPEC_PATH
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace

--- a/pipeline/generate-preview-package.yaml
+++ b/pipeline/generate-preview-package.yaml
@@ -24,25 +24,16 @@ spec:
       source /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    workingDir: /workspace/source
   - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:0.1.7
     name: moves-like-swagger
     resources: {}
     script: |
       #!/usr/bin/env sh
       source /workspace/source/.jx/variables.sh
+      
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip):5000/swagger/v1/swagger.json)
       cd ./registry
-      
-      SWAG_PATH=$(find /workspace/source -type f -name "swagger.json")
-      if test $SWAG_PATH ; then
-        echo Swagger docs found in repository
-      else
-        SWAG_PATH=http://$(cat ../pod_ip):5000/swagger/v1/swagger.json
-        echo Swagger docs not found in repository, using staging
-      fi
-      
-      /CreateAngularPackageV2.sh $SWAG_PATH
-    workingDir: /workspace/source
+      /CreateAngularPackageV2.sh $SPEC_PATH
   workspaces:
   - description: The git repo will be cloned onto the volume backing this workspace
     mountPath: /workspace

--- a/pipeline/generate-preview-package.yaml
+++ b/pipeline/generate-preview-package.yaml
@@ -31,7 +31,7 @@ spec:
       #!/usr/bin/env sh
       source /workspace/source/.jx/variables.sh
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://$(cat ../pod_ip):5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)":5000/swagger/v1/swagger.json)
       cd ./registry
       /CreateAngularPackageV2.sh $SPEC_PATH
   workspaces:

--- a/pipeline/generate-preview-package.yaml
+++ b/pipeline/generate-preview-package.yaml
@@ -31,7 +31,7 @@ spec:
       #!/usr/bin/env sh
       source /workspace/source/.jx/variables.sh
       
-      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ../pod_ip)":5000/swagger/v1/swagger.json)
+      SPEC_PATH=$(/FindOpenAPISpec.sh http://"$(cat ./pod_ip)":5000/swagger/v1/swagger.json)
       cd ./registry
       /CreateAngularPackageV2.sh $SPEC_PATH
   workspaces:


### PR DESCRIPTION
* Moved finding the swagger/openapi specs to a common script
* Using absolute paths for the specs as some pipelines have to cd into `/.registry ` before running the generator

!This will break package generation as the pipeline base images will need to be updated post merge!