### PR TITLE
chore: rename pipeline build-push-DANGER

### DIFF
--- a/.lighthouse/jenkins-x/pullrequest.yaml
+++ b/.lighthouse/jenkins-x/pullrequest.yaml
@@ -26,7 +26,7 @@ spec:
           resources: {}
         - name: check-registry
           resources: {}
-        - image: uses:spring-financial-group/DevOps/pipelines/build-push-rules.yaml@main
+        - image: uses:spring-financial-group/DevOps/pipelines/build-push-DANGER.yaml@main
           name: ""
           resources: {}
   podTemplate: {}

--- a/.lighthouse/jenkins-x/release.yaml
+++ b/.lighthouse/jenkins-x/release.yaml
@@ -28,7 +28,7 @@ spec:
           resources: {}
         - name: check-registry
           resources: {}
-        - image: uses:spring-financial-group/DevOps/pipelines/build-push-rules.yaml@main
+        - image: uses:spring-financial-group/DevOps/pipelines/build-push-DANGER.yaml@main
           name: ""
           resources: {}
         - name: promote-changelog


### PR DESCRIPTION
We renamed build-push-rules (no scan) -> build-push-DANGER to get any services off using it