### PR TITLE
fix: dependencies in generated angular package

### DIFF
--- a/.lighthouse/jenkins-x/integration.yaml
+++ b/.lighthouse/jenkins-x/integration.yaml
@@ -60,7 +60,7 @@ spec:
                 #!/bin/bash
                 source /workspace/source/.jx/variables.sh
                 cd ./mocks
-                ./jx3-openapi-generation generate packages python
+                ./jx3-openapi-generation generate packages angular csharp java
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 1h0m0s

--- a/pkg/packageGenerator/angular/generator.go
+++ b/pkg/packageGenerator/angular/generator.go
@@ -39,6 +39,11 @@ func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 		return "", err
 	}
 
+	_, err = g.getPackageJSON(packageDir)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get package.json")
+	}
+
 	err = g.FileIO.CopyManyToDir(packageDir, TSConfigPath, ConfigurationTSPath)
 	if err != nil {
 		return "", err
@@ -56,7 +61,7 @@ func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 
 	distDir := filepath.Join(outputDir, "dist")
 
-	// Copy the package.json file & replace the version
+	// Copy the original package.json to the dist directory to remove the dependencies
 	_, err = g.getPackageJSON(distDir)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to get package.json")

--- a/pkg/packageGenerator/angular/generator.go
+++ b/pkg/packageGenerator/angular/generator.go
@@ -39,20 +39,9 @@ func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 		return "", err
 	}
 
-	// Copy the package.json file & replace the version
-	packageJSONPath, err := g.getPackageJSON(packageDir)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to get package.json")
-	}
-
 	err = g.FileIO.CopyManyToDir(packageDir, TSConfigPath, ConfigurationTSPath)
 	if err != nil {
 		return "", err
-	}
-
-	err = g.installNPMPackages(packageDir)
-	if err != nil {
-		return "", errors.Wrap(err, "failed to install npm packages")
 	}
 
 	err = g.installNPMPackages(packageDir, RXJS, Zone, AngularCore, AngularCommon)
@@ -66,7 +55,14 @@ func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 	}
 
 	distDir := filepath.Join(outputDir, "dist")
-	err = g.FileIO.CopyManyToDir(distDir, NPMRCPath, ConfigurationTSPath, packageJSONPath)
+
+	// Copy the package.json file & replace the version
+	_, err = g.getPackageJSON(distDir)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to get package.json")
+	}
+
+	err = g.FileIO.CopyManyToDir(distDir, NPMRCPath, ConfigurationTSPath)
 	if err != nil {
 		return "", err
 	}


### PR DESCRIPTION
Dependencies to packages installed during angular package generation are being brought into the package.json stopping the package from being installed.

This PR stops this from happening.