### PR TITLE
feat: set version on all old-style pipelines

### DIFF
--- a/pipeline/generate-csharp-package-nonapigw.yaml
+++ b/pipeline/generate-csharp-package-nonapigw.yaml
@@ -23,7 +23,7 @@ spec:
       #!/usr/bin/env sh
       . /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: csharp-swagger
     resources: {}
     script: |

--- a/pipeline/generate-csharp-package.yaml
+++ b/pipeline/generate-csharp-package.yaml
@@ -23,7 +23,7 @@ spec:
       #!/usr/bin/env sh
       . /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: csharp-swagger
     resources: {}
     script: |

--- a/pipeline/generate-java-package-v3.yaml
+++ b/pipeline/generate-java-package-v3.yaml
@@ -23,7 +23,7 @@ spec:
         #!/usr/bin/env sh
         . /workspace/source/.jx/variables.sh
         sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-    - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+    - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
       name: java-swagger
       resources: {}
       script: |

--- a/pipeline/generate-package-v3.yaml
+++ b/pipeline/generate-package-v3.yaml
@@ -23,7 +23,7 @@ spec:
       #!/usr/bin/env sh
       . /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: moves-like-swagger
     resources: {}
     script: |

--- a/pipeline/generate-package.yaml
+++ b/pipeline/generate-package.yaml
@@ -23,7 +23,7 @@ spec:
       #!/usr/bin/env sh
       source /workspace/source/.jx/variables.sh
       sed -i 's/0.0.0/'$VERSION'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: moves-like-swagger
     resources: {}
     script: |

--- a/pipeline/generate-preview-csharp-calcvalues-package.yaml
+++ b/pipeline/generate-preview-csharp-calcvalues-package.yaml
@@ -24,7 +24,7 @@ spec:
       . /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-ring-financial-group-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: csharp-swagger
     resources: {}
     script: |

--- a/pipeline/generate-preview-csharp-package.yaml
+++ b/pipeline/generate-preview-csharp-package.yaml
@@ -24,7 +24,7 @@ spec:
       . /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: csharp-swagger
     resources: {}
     script: |

--- a/pipeline/generate-preview-golang-csharp-package.yaml
+++ b/pipeline/generate-preview-golang-csharp-package.yaml
@@ -24,7 +24,7 @@ spec:
       . /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: csharp-swagger
     resources: {}
     script: |

--- a/pipeline/generate-preview-golang-package-v3.yaml
+++ b/pipeline/generate-preview-golang-package-v3.yaml
@@ -24,7 +24,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: moves-like-swagger
     resources: {}
     script: |

--- a/pipeline/generate-preview-java-package-v3.yaml
+++ b/pipeline/generate-preview-java-package-v3.yaml
@@ -24,7 +24,7 @@ spec:
         . /workspace/source/.jx/variables.sh
         echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
         sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-    - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+    - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
       name: java-swagger
       resources: {}
       script: |

--- a/pipeline/generate-preview-package-v3.yaml
+++ b/pipeline/generate-preview-package-v3.yaml
@@ -24,7 +24,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: moves-like-swagger
     resources: {}
     script: |

--- a/pipeline/generate-preview-package.yaml
+++ b/pipeline/generate-preview-package.yaml
@@ -24,7 +24,7 @@ spec:
       source /workspace/source/.jx/variables.sh
       echo $(kubectl get services -A | grep jx-$REPO_OWNER-$APP_NAME-pr-$PULL_NUMBER | awk '$2 == "'$APP_NAME'" {print $4}') > pod_ip
       sed -i 's/0.0.0/0.0.'$PULL_NUMBER'-rc.'$BUILD_ID'/g' ./registry/package.json
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:1.1.0
     name: moves-like-swagger
     resources: {}
     script: |


### PR DESCRIPTION
Setting the version to a stable image of the repository for all old-style pipelines so that the version of the openapi-generation tool can be updated without affecting them. Once all the repositories have been migrated these will be removed.