### PR TITLE
fix(java): model naming (convert pascal to camel case)

### DIFF
--- a/pkg/packageGenerator/java/generator.go
+++ b/pkg/packageGenerator/java/generator.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/domain"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/utils"
 	"path/filepath"
 	"strings"
 )
@@ -38,13 +39,18 @@ func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 }
 
 func (g *Generator) setDynamicConfigVariables() {
-	g.Cfg.GeneratorCLI.Generators[domain.Java].AdditionalProperties["basePackage"] = g.GetPackageName()
-	g.Cfg.GeneratorCLI.Generators[domain.Java].AdditionalProperties["modelPackage"] = fmt.Sprintf("%s.models", g.GetPackageName())
+	g.Cfg.GeneratorCLI.Generators[domain.Java].AdditionalProperties["basePackage"] = g.getModelName()
+	g.Cfg.GeneratorCLI.Generators[domain.Java].AdditionalProperties["modelPackage"] = fmt.Sprintf("%s.models", g.getModelName())
 }
 
 func (g *Generator) GetPackageName() string {
 	// Replace first hyphen with a dot mqube-foo-service -> mqube.foo-service
 	return strings.Replace(g.RepoName, "-", ".", 1)
+}
+
+func (g *Generator) getModelName() string {
+	// convert pascal case to camel case
+	return fmt.Sprintf("mqube.%s", utils.FirstCharToLower(g.ServiceName))
 }
 
 func (g *Generator) PushPackage(packageDir string) error {

--- a/pkg/utils/utils.go
+++ b/pkg/utils/utils.go
@@ -1,6 +1,19 @@
 package utils
 
-import "encoding/json"
+import (
+	"encoding/json"
+	"unicode"
+)
+
+// FirstCharToLower converts the first character of a string to lowercase
+func FirstCharToLower(s string) string {
+	if len(s) == 0 {
+		return s
+	}
+	a := []rune(s)
+	a[0] = unicode.ToLower(a[0])
+	return string(a)
+}
 
 // NewPtr returns a pointer to the input
 func NewPtr[T any](val T) *T {

--- a/pkg/utils/utils_test.go
+++ b/pkg/utils/utils_test.go
@@ -1,0 +1,42 @@
+package utils_test
+
+import (
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/utils"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+func TestFirstCharToLower(t *testing.T) {
+	testCases := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{
+			name:     "empty string",
+			input:    "",
+			expected: "",
+		},
+		{
+			name:     "single character",
+			input:    "A",
+			expected: "a",
+		},
+		{
+			name:     "multiple characters",
+			input:    "ABC",
+			expected: "aBC",
+		},
+		{
+			name:     "service name",
+			input:    "FooService",
+			expected: "fooService",
+		},
+	}
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			actual := utils.FirstCharToLower(tc.input)
+			assert.Equal(t, tc.expected, actual)
+		})
+	}
+}


### PR DESCRIPTION
Resolves the java model package naming issues.

Generated a test package for expenditure and installed in rules showing:
![image](https://github.com/spring-financial-group/jx3-openapi-generation/assets/89483637/12d1ebe2-dedf-4226-a203-efca3e1947b3)
