### PR TITLE
chore: python Extra fields ignore

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:14
 
 RUN apt-get update
 
-# Install python dependencies
-RUN apt-get install python3-pip -y && pip3 install datamodel-code-generator
-
 # Install node dependencies
 RUN npm install -g @openapitools/openapi-generator-cli@2.6.0
 RUN npm install -g @angular/compiler-cli@13.3.1 @angular/platform-server@13.3.1 @angular/compiler@13.3.1

--- a/pipeline/generate-python-package.yaml
+++ b/pipeline/generate-python-package.yaml
@@ -77,6 +77,17 @@ spec:
         datamodel-codegen  --input /workspace/source/spec.json --input-file-type auto --output "$serviceName"/schemas.py
         echo > "$serviceName"/__init__.py
 
+        # Replace Extra.forbid with Extra.ignore
+        # if env var EXTRA_FIELD_IGNORE is True
+        python3 << HEREDOC
+        import os
+        from pathlib import Path
+        if os.getenv('EXTRA_FIELD_IGNORE', False) == 'True':
+          path = Path('$serviceName/schemas.py')
+          content = content.replace('extra = Extra.forbid', 'Extra.ignore')
+          path.write_text(content)
+        HEREDOC
+
         new_packages_json=`cat packages.json | python3 -c "import sys, json; packages=json.load(sys.stdin); packages['$REPO_NAME']={'dir':'$serviceName','name':'$REPO_NAME','version':'$VERSION'}; print(json.dumps(packages,indent=4))"`
         echo "$new_packages_json" > packages.json
 


### PR DESCRIPTION
Some Schemas automatically add Extra.forbid even when they are not required.
This change is to add an env var to the pipeline to control this behaviour by replacing all occurrences of Extra.forbid to Extra.ignore in the pydantic models

closes spring-financial-group/Backlog-and-Sprints#10614