### PR TITLE
fix: remove Python deps from dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,9 +2,6 @@ FROM node:14
 
 RUN apt-get update
 
-# Install python dependencies
-RUN apt-get install python3-pip -y && pip3 install datamodel-code-generator
-
 # Install node dependencies
 RUN npm install -g @openapitools/openapi-generator-cli@2.6.0
 RUN npm install -g @angular/compiler-cli@13.3.1 @angular/platform-server@13.3.1 @angular/compiler@13.3.1


### PR DESCRIPTION
Python deps are causing build issues. Python isn't required in the Dockerfile currently as the python pipe uses the python image so safe to remove.