### PR TITLE
chore: Python gen defaulting to optional fields

### DIFF
--- a/pipeline/generate-python-package.yaml
+++ b/pipeline/generate-python-package.yaml
@@ -86,7 +86,7 @@ spec:
         approach = os.getenv('PY_EXTRA_FIELD_CONFIG', 'ignore')
         valid_approaches = {'allow', 'forbid', 'ignore'}
         assert approach in valid_approaches, f"{approach} not a valid config for python extra fields - select from one of: {valid_approaches}"
-        print("Extra field config: {approach}")
+        print(f"Extra field config: {approach}")
         path = Path('$serviceName/schemas.py')
         content = path.read_text()
         content = content.replace('extra = Extra.forbid', f'extra = Extra.{approach}')

--- a/pipeline/generate-python-package.yaml
+++ b/pipeline/generate-python-package.yaml
@@ -83,16 +83,15 @@ spec:
         print('Inside Python HEREDOC')
         import os
         from pathlib import Path
-        env_var = os.getenv("EXTRA_FIELD_IGNORE", "NOT FOUND")
-        print(f'EXTRA_FIELD_IGNORE: {env_var}')
-        print(f'EXTRA_FIELD_IGNORE: {type(env_var)}')
-        print(f'Considition Passed: {env_var == "True"}')
-        if os.getenv('EXTRA_FIELD_IGNORE', False) == 'True':
-          path = Path('$serviceName/schemas.py')
-          content = path.read_text()
-          content = content.replace('extra = Extra.forbid', 'extra = Extra.ignore')
-          path.write_text(content)
-          print(f'Change successful')
+        approach = os.getenv('PY_EXTRA_FIELD_CONFIG', 'ignore')
+        valid_approaches = {'allow', 'forbid', 'ignore'}
+        assert approach in valid_approaches, f"{approach} not a valid config for python extra fields - select from one of: {valid_approaches}"
+        print("Extra field config: {approach}")
+        path = Path('$serviceName/schemas.py')
+        content = path.read_text()
+        content = content.replace('extra = Extra.forbid', f'extra = Extra.{approach}')
+        path.write_text(content)
+        print(f'Change successful')
         HEREDOC
 
         new_packages_json=`cat packages.json | python3 -c "import sys, json; packages=json.load(sys.stdin); packages['$REPO_NAME']={'dir':'$serviceName','name':'$REPO_NAME','version':'$VERSION'}; print(json.dumps(packages,indent=4))"`


### PR DESCRIPTION
Generated python models are currently set to throw an error if any additional field is present. This effectively turns `feat` changes into breaking changes as any new fields prevent the service from working as normal.

This changes the approach so that it is by default optional. The env var EXTRA_FIELD_IGNORE is now superseded by PY_EXTRA_FIELD_CONFIG in which the exact approach desired is specified. 