### PR TITLE
fix: git add pydantic v2 schema

### DIFF
--- a/pipeline/generate-python-package.yaml
+++ b/pipeline/generate-python-package.yaml
@@ -98,7 +98,7 @@ spec:
         new_packages_json=`cat packages.json | python3 -c "import sys, json; packages=json.load(sys.stdin); packages['$REPO_NAME']={'dir':'$serviceName','name':'$REPO_NAME','version':'$VERSION'}; print(json.dumps(packages,indent=4))"`
         echo "$new_packages_json" > packages.json
 
-        git add "$serviceName"/schemas.py "$serviceName"/__init__.py packages.json
+        git add "$serviceName"/schemas.py "$serviceName"/__init__.py packages.json "$serviceName"/schemas_v2.py
         git commit -m "chore(deps): upgrade $serviceName package -> v$VERSION"
         git push --set-upstream origin "$branch"
         gh pr create --title "chore(deps): upgrade $serviceName package -> v$VERSION" --body "Automated python schemas update for $serviceName" --reviewer Reton2 --base master --head "$branch" -l updatebot


### PR DESCRIPTION
Forgot to add with git
https://github.com/spring-financial-group/jx3-openapi-generation/blob/884768aaa02c0d3afa0df76e7983c79a311ed36b/pipeline/generate-python-package.yaml#L78