### PR TITLE
fix: use Jackson for Java Generation

### DIFF
--- a/CreateJavaPackage.sh
+++ b/CreateJavaPackage.sh
@@ -1,6 +1,6 @@
 set -e
 
-specurl=$1
+specurl\=$1
 version=$2
 name=$3
 repoOwner=$4
@@ -24,7 +24,7 @@ esac
 cp /openapitools.json ./openapitools.json
 
 echo Generating API
-npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime serializationLibrary=jackson
+npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson
 
 echo "Set version to build.gradle" && sed -i "s|version = '0.0.0'|version = '${version}'|" ./build.gradle
 echo "Copying Gradle file" && cp ./build.gradle ./java_service/build.gradle

--- a/CreateJavaPackage.sh
+++ b/CreateJavaPackage.sh
@@ -24,7 +24,7 @@ esac
 cp /openapitools.json ./openapitools.json
 
 echo Generating API
-npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson
+npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson -p library=restclient
 
 echo "Set version to build.gradle" && sed -i "s|version = '0.0.0'|version = '${version}'|" ./build.gradle
 echo "Copying Gradle file" && cp ./build.gradle ./java_service/build.gradle

--- a/CreateJavaPackage.sh
+++ b/CreateJavaPackage.sh
@@ -1,6 +1,6 @@
 set -e
 
-specurl\=$1
+specurl=$1
 version=$2
 name=$3
 repoOwner=$4

--- a/CreateJavaPackage.sh
+++ b/CreateJavaPackage.sh
@@ -24,7 +24,7 @@ esac
 cp /openapitools.json ./openapitools.json
 
 echo Generating API
-npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime
+npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime serializationLibrary=jackson
 
 echo "Set version to build.gradle" && sed -i "s|version = '0.0.0'|version = '${version}'|" ./build.gradle
 echo "Copying Gradle file" && cp ./build.gradle ./java_service/build.gradle

--- a/CreateJavaPackage.sh
+++ b/CreateJavaPackage.sh
@@ -24,7 +24,7 @@ esac
 cp /openapitools.json ./openapitools.json
 
 echo Generating API
-npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson -p library=restclient
+npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson -p library=resttemplate
 
 echo "Set version to build.gradle" && sed -i "s|version = '0.0.0'|version = '${version}'|" ./build.gradle
 echo "Copying Gradle file" && cp ./build.gradle ./java_service/build.gradle

--- a/CreateJavaPackage.sh
+++ b/CreateJavaPackage.sh
@@ -24,7 +24,7 @@ esac
 cp /openapitools.json ./openapitools.json
 
 echo Generating API
-npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson -p library=resttemplate
+npx openapi-generator-cli generate -i ./spec.json -g java -o java_service --git-user-id $repoOwner --git-repo-id $repoId --global-property models,modelTests=false,modelDocs=false -p basePackage=$name -p modelPackage=${name}.models -p dateLibrary=java8-localdatetime -p serializationLibrary=jackson -p library=webclient
 
 echo "Set version to build.gradle" && sed -i "s|version = '0.0.0'|version = '${version}'|" ./build.gradle
 echo "Copying Gradle file" && cp ./build.gradle ./java_service/build.gradle

--- a/openapitools.json
+++ b/openapitools.json
@@ -20,7 +20,8 @@
         "inputSpec": "./mocks/swagger.json",
         "generatorName": "java",
         "additionalProperties": {
-          "dateLibrary": "java8-localdatetime"
+          "dateLibrary": "java8-localdatetime",
+          "serializationLibrary": "jackson"
         },
         "globalProperty": {
           "models": "",

--- a/openapitools.json
+++ b/openapitools.json
@@ -22,7 +22,7 @@
         "additionalProperties": {
           "dateLibrary": "java8-localdatetime",
           "serializationLibrary": "jackson",
-          "library": "restclient"
+          "library": "resttemplate"
         },
         "globalProperty": {
           "models": "",

--- a/openapitools.json
+++ b/openapitools.json
@@ -23,7 +23,7 @@
           "dateLibrary": "java8-localdatetime",
           "serializationLibrary": "jackson",
           "library": "webclient",
-          "openApiNullable": true
+          "openApiNullable": false
         },
         "globalProperty": {
           "models": "",

--- a/openapitools.json
+++ b/openapitools.json
@@ -22,7 +22,7 @@
         "additionalProperties": {
           "dateLibrary": "java8-localdatetime",
           "serializationLibrary": "jackson",
-          "library": "resttemplate"
+          "library": "webclient"
         },
         "globalProperty": {
           "models": "",

--- a/openapitools.json
+++ b/openapitools.json
@@ -21,7 +21,8 @@
         "generatorName": "java",
         "additionalProperties": {
           "dateLibrary": "java8-localdatetime",
-          "serializationLibrary": "jackson"
+          "serializationLibrary": "jackson",
+          "library": "restclient"
         },
         "globalProperty": {
           "models": "",

--- a/openapitools.json
+++ b/openapitools.json
@@ -23,7 +23,7 @@
           "dateLibrary": "java8-localdatetime",
           "serializationLibrary": "jackson",
           "library": "webclient",
-          "openApiNullable": false
+          "openApiNullable": "false"
         },
         "globalProperty": {
           "models": "",

--- a/openapitools.json
+++ b/openapitools.json
@@ -22,7 +22,8 @@
         "additionalProperties": {
           "dateLibrary": "java8-localdatetime",
           "serializationLibrary": "jackson",
-          "library": "webclient"
+          "library": "webclient",
+          "openApiNullable": true
         },
         "globalProperty": {
           "models": "",

--- a/pipeline/generate-packages.yaml
+++ b/pipeline/generate-packages.yaml
@@ -26,7 +26,7 @@ spec:
     resources: {}
     workingDir: /workspace/source
   steps:
-  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest
+  - image: jx3mqubebuild.azurecr.io/spring-financial-group/jx3-openapi-generation:latest-preview
     name: package-generation
     resources: {}
     script: |


### PR DESCRIPTION
Previously the serialisation library defaulted to Gson. In Spring applications the default is Jackson, which is used in mqube-rules. This has caused some serialisation issues with the Product service client, trying to serialise the mock using Jackson when it defaults to Gson.