### PR TITLE
fix: Add the Package Name options as a Env Var

### DIFF
--- a/pkg/cmd/generate/generate.go
+++ b/pkg/cmd/generate/generate.go
@@ -29,7 +29,8 @@ type Options struct {
 	GitUser            string
 	GitToken           string
 
-	FileIO domain.FileIO
+	FileIO      domain.FileIO
+	PackageName string
 }
 
 // Constants for environment variables required by the command
@@ -41,6 +42,7 @@ const (
 	specPathKey           = "SpecPath"
 	gitUserKey            = "GIT_USER"
 	gitTokenKey           = "GIT_TOKEN"
+	packageNameKey        = "PackageName"
 )
 
 const (
@@ -120,6 +122,9 @@ func (o *Options) getVariablesFromEnvironment() error {
 	}
 	if o.SwaggerServiceName = os.Getenv(swaggerServiceNameKey); o.SwaggerServiceName == "" {
 		missingVariables = append(missingVariables, swaggerServiceNameKey)
+	}
+	if o.PackageName = os.Getenv(packageNameKey); o.PackageName == "" {
+		o.PackageName = "Client"
 	}
 	if o.SpecPath = os.Getenv(specPathKey); o.SpecPath == "" {
 		missingVariables = append(missingVariables, specPathKey)

--- a/pkg/cmd/generate/generate_packages.go
+++ b/pkg/cmd/generate/generate_packages.go
@@ -125,7 +125,7 @@ func (o *PackageOptions) InitialiseGenerators() error {
 	if err != nil {
 		return err
 	}
-	baseGenerator, err := packageGenerator.NewBaseGenerator(o.Version, o.SwaggerServiceName, o.RepoOwner, o.RepoName, o.GitToken, o.GitUser, o.SpecPath, config)
+	baseGenerator, err := packageGenerator.NewBaseGenerator(o.Version, o.SwaggerServiceName, o.RepoOwner, o.RepoName, o.GitToken, o.GitUser, o.SpecPath, o.PackageName, config)
 	if err != nil {
 		return errors.Wrap(err, "failed to create base generator")
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,7 +17,7 @@ func Main() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := cmd.Help()
 			if err != nil {
-				log.Logger().Errorf("%s", err.Error())
+				log.Logger().Error(err.Error())
 			}
 		},
 	}

--- a/pkg/cmd/root.go
+++ b/pkg/cmd/root.go
@@ -17,7 +17,7 @@ func Main() *cobra.Command {
 		Run: func(cmd *cobra.Command, args []string) {
 			err := cmd.Help()
 			if err != nil {
-				log.Logger().Errorf(err.Error())
+				log.Logger().Errorf("%s", err.Error())
 			}
 		},
 	}

--- a/pkg/commandRunner/cmdrunner.go
+++ b/pkg/commandRunner/cmdrunner.go
@@ -34,7 +34,7 @@ func (c *CommandRunner) ExecuteAndLog(dir, name string, args ...string) error {
 	log.Logger().Infof("%sRunning command%s:%s %s %s", utils.Cyan, dirString, utils.Reset, name, strings.Join(args, " "))
 	out, err := c.Execute(dir, name, args...)
 	if err != nil {
-		log.Logger().Errorf(out)
+		log.Logger().Errorf("%d", out)
 		return err
 	}
 	if out != "" {

--- a/pkg/commandRunner/cmdrunner.go
+++ b/pkg/commandRunner/cmdrunner.go
@@ -34,11 +34,11 @@ func (c *CommandRunner) ExecuteAndLog(dir, name string, args ...string) error {
 	log.Logger().Infof("%sRunning command%s:%s %s %s", utils.Cyan, dirString, utils.Reset, name, strings.Join(args, " "))
 	out, err := c.Execute(dir, name, args...)
 	if err != nil {
-		log.Logger().Errorf("%d", out)
+		log.Logger().Errorf("%s", out)
 		return err
 	}
 	if out != "" {
-		log.Logger().Infof(out)
+		log.Logger().Infof("%s", out)
 	}
 	return nil
 }

--- a/pkg/commandRunner/cmdrunner.go
+++ b/pkg/commandRunner/cmdrunner.go
@@ -34,11 +34,11 @@ func (c *CommandRunner) ExecuteAndLog(dir, name string, args ...string) error {
 	log.Logger().Infof("%sRunning command%s:%s %s %s", utils.Cyan, dirString, utils.Reset, name, strings.Join(args, " "))
 	out, err := c.Execute(dir, name, args...)
 	if err != nil {
-		log.Logger().Errorf("%s", out)
+		log.Logger().Error(out)
 		return err
 	}
 	if out != "" {
-		log.Logger().Infof("%s", out)
+		log.Logger().Info(out)
 	}
 	return nil
 }

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -75,7 +75,7 @@ func (c *Client) GetDefaultBranchName(dir string) (string, error) {
 
 func (c *Client) log(message string) {
 	if message != "" {
-		log.Logger().Infof(message)
+		log.Logger().Infof("%s", message)
 	}
 }
 

--- a/pkg/git/git.go
+++ b/pkg/git/git.go
@@ -75,7 +75,7 @@ func (c *Client) GetDefaultBranchName(dir string) (string, error) {
 
 func (c *Client) log(message string) {
 	if message != "" {
-		log.Logger().Infof("%s", message)
+		log.Logger().Info(message)
 	}
 }
 

--- a/pkg/packageGenerator/angular/generator.go
+++ b/pkg/packageGenerator/angular/generator.go
@@ -85,7 +85,7 @@ func (g *Generator) GetPackageName() string {
 
 func (g *Generator) PushPackage(packageDir string) error {
 	out, err := g.Cmd.Execute(packageDir, "npm", "publish")
-	log.Logger().Infof(out)
+	log.Logger().Infof("%s", out)
 	if err != nil {
 		// NPM returns the error message on STDOUT, so we need to check there for the error
 		if strings.Contains(out, errNPMVersionAlreadyExists) {

--- a/pkg/packageGenerator/angular/generator.go
+++ b/pkg/packageGenerator/angular/generator.go
@@ -85,7 +85,7 @@ func (g *Generator) GetPackageName() string {
 
 func (g *Generator) PushPackage(packageDir string) error {
 	out, err := g.Cmd.Execute(packageDir, "npm", "publish")
-	log.Logger().Infof("%s", out)
+	log.Logger().Info(out)
 	if err != nil {
 		// NPM returns the error message on STDOUT, so we need to check there for the error
 		if strings.Contains(out, errNPMVersionAlreadyExists) {

--- a/pkg/packageGenerator/base_generator.go
+++ b/pkg/packageGenerator/base_generator.go
@@ -16,13 +16,14 @@ type BaseGenerator struct {
 	GitToken    string
 	GitUser     string
 	SpecPath    string
+	PackageName string
 
 	Cfg    *openapitools.Config
 	Cmd    domain.CommandRunner
 	FileIO domain.FileIO
 }
 
-func NewBaseGenerator(version, serviceName, repoOwner, repoName, gitToken, gitUser, specPath string, cfg *openapitools.Config) (*BaseGenerator, error) {
+func NewBaseGenerator(version, serviceName, repoOwner, repoName, gitToken, gitUser, specPath string, packageName string, cfg *openapitools.Config) (*BaseGenerator, error) {
 	gen := &BaseGenerator{
 		Version:     version,
 		ServiceName: serviceName,
@@ -31,6 +32,7 @@ func NewBaseGenerator(version, serviceName, repoOwner, repoName, gitToken, gitUs
 		GitUser:     gitUser,
 		GitToken:    gitToken,
 		SpecPath:    specPath,
+		PackageName: packageName,
 		Cmd:         commandRunner.NewCommandRunner(),
 		FileIO:      file.NewFileIO(),
 		Cfg:         cfg,

--- a/pkg/packageGenerator/csharp/generator.go
+++ b/pkg/packageGenerator/csharp/generator.go
@@ -46,7 +46,7 @@ func (g *Generator) setDynamicConfigVariables() {
 }
 
 func (g *Generator) GetPackageName() string {
-	return fmt.Sprintf("Mqube.%s.Client", g.ServiceName)
+	return fmt.Sprintf("Mqube.%s.%s", g.ServiceName, g.PackageName)
 }
 
 func (g *Generator) PushPackage(packageDir string) error {

--- a/pkg/packageGenerator/javascript/generator.go
+++ b/pkg/packageGenerator/javascript/generator.go
@@ -65,7 +65,7 @@ func (g *Generator) GetPackageName() string {
 
 func (g *Generator) PushPackage(packageDir string) error {
 	out, err := g.Cmd.Execute(packageDir, "npm", "publish")
-	log.Logger().Infof(out)
+	log.Logger().Infof("%s", out)
 	if err != nil {
 		// NPM returns the error message on STDOUT, so we need to check there for the error
 		if strings.Contains(out, errNPMVersionAlreadyExists) {

--- a/pkg/packageGenerator/javascript/generator.go
+++ b/pkg/packageGenerator/javascript/generator.go
@@ -65,7 +65,7 @@ func (g *Generator) GetPackageName() string {
 
 func (g *Generator) PushPackage(packageDir string) error {
 	out, err := g.Cmd.Execute(packageDir, "npm", "publish")
-	log.Logger().Infof("%s", out)
+	log.Logger().Info(out)
 	if err != nil {
 		// NPM returns the error message on STDOUT, so we need to check there for the error
 		if strings.Contains(out, errNPMVersionAlreadyExists) {


### PR DESCRIPTION
run the Package Gen and publish multiple times in a pipeline not the best approach but less change to the core code and only matters for third parties generating their packages