### PR TITLE
chore(deps): replace strings as per the updates

### DIFF
--- a/.lighthouse/jenkins-x/golint.yaml
+++ b/.lighthouse/jenkins-x/golint.yaml
@@ -14,7 +14,7 @@ spec:
             - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
               name: ""
               resources: {}
-            - image: uses:spring-financial-group/DevOps/pipelines/golang-lint.yaml@main
+            - image: uses:spring-financial-group/mqube-pipeline-catalog/tasks/go/golang-lint.yaml@main
               name: ""
               resources: {}
   podTemplate: {}


### PR DESCRIPTION
This pull request replaces the following string pairs:

- File: /home/gav/projects/stringchange-repos/jx3-openapi-generation/.lighthouse/jenkins-x/golint.yaml
  - `uses:spring-financial-group/DevOps/pipelines/golang-lint.yaml` → `uses:spring-financial-group/mqube-pipeline-catalog/tasks/go/golang-lint.yaml`
