### PR TITLE
fix: replace suffix Response with ResponseDto

### DIFF
--- a/pkg/packageGenerator/go/generator.go
+++ b/pkg/packageGenerator/go/generator.go
@@ -235,6 +235,11 @@ func (g *Generator) generateCode() (string, error) {
 		return "", err
 	}
 
+	// replace all `Response"` occurences with `ResponseDto"` to avoid compilation errors
+	swaggerString := string(swaggerData)
+	swaggerString = strings.ReplaceAll(swaggerString, "Response\"", "ResponseDto\"")
+	swaggerData = []byte(swaggerString)
+
 	loader := openapi3.NewLoader()
 	swagger, err := loader.LoadFromData(swaggerData)
 	if err != nil {
@@ -267,9 +272,6 @@ func (g *Generator) generateCode() (string, error) {
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate code")
 	}
-
-	// replace all `Response"` occurences with `ResponseDto"` to avoid compilation errors
-	code = strings.ReplaceAll(code, "Response\"", "ResponseDto\"")
 
 	return code, nil
 }

--- a/pkg/packageGenerator/go/generator.go
+++ b/pkg/packageGenerator/go/generator.go
@@ -268,6 +268,9 @@ func (g *Generator) generateCode() (string, error) {
 		return "", errors.Wrap(err, "failed to generate code")
 	}
 
+	// replace all `Response"` occurences with `ResponseDto"` to avoid compilation errors
+	code = strings.ReplaceAll(code, "Response\"", "ResponseDto\"")
+
 	return code, nil
 }
 


### PR DESCRIPTION
# Context
When an object and handler have the same name and the object name ends with `Response`, go package generation breaks
Replacing all occurrences of `Response` as a suffix of any name with `ResponseDto`

e.g. https://github.com/spring-financial-group/mqube-go-packages/pull/89