### PR TITLE
chore: remove reviewers for go pkg gen

### DIFF
--- a/pkg/packageGenerator/go/generator.go
+++ b/pkg/packageGenerator/go/generator.go
@@ -30,7 +30,7 @@ const (
 )
 
 var (
-	reviewers = []string{"Skisocks", "Reton2"}
+	reviewers = []string{}
 )
 
 type Generator struct {


### PR DESCRIPTION
### Context
It's working now, don't need reviewers anymore