### PR TITLE
chore: update openapi-generator-cli

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -10,7 +10,7 @@ RUN go install github.com/vektra/mockery/v2@v2.52.2
 RUN go version
 
 # Install javascript dependencies
-RUN npm install -g @openapitools/openapi-generator-cli@2.13.4
+RUN npm install -g @openapitools/openapi-generator-cli@2.21.0
 RUN npm install -g @angular/compiler-cli@13.3.1 @angular/platform-server@13.3.1 @angular/compiler@13.3.1
 RUN npm install -g typescript@4.6.3
 


### PR DESCRIPTION
### Changes
* Updating openapi-generator-cli to v2.21.0

### Context
Updating cli generator version.
Current version does not support swagger v3.1.0, checking if this will