### PR TITLE
fix: add gen alias as model for angular

### DIFF
--- a/openapitools.json
+++ b/openapitools.json
@@ -38,7 +38,8 @@
         "additionalProperties": {
           "fileNaming": "camelCase",
           "ngVersion": "10.0.0",
-          "stringEnums": "true"
+          "stringEnums": "true",
+          "generateAliasAsModel": "true"
         }
       },
       "python": {


### PR DESCRIPTION
### Changes
- Added `generateAliasAsModel` to angular config

### Context
When generating the angular package for docgen, it is skipping over domain.BatchDocumentContent and domain.DocumentContent due to the error: 
`Model domain.BatchDocumentContent not generated since it's an alias to map (without property) and generateAliasAsModel is set to false (default)`

enabling this should hopefully fix this.