### PR TITLE
feat: rust package gen

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,6 +13,7 @@ The following languages currently are supported:
 | Typescript | `typescript` |                                         |
 | Python     | `python`     | **Not available for preview packages*** |
 | Golang     | `go`         | **Not available for preview packages*** |
+| Rust       | `rust`       |                                         |
 
 \* Due to the way in which Go and Python packages are stored preview packages are not current supported so avoid
 using these languages in any preview pipelines

--- a/openapitools.json
+++ b/openapitools.json
@@ -90,6 +90,16 @@
           "packageVersion": "0.0.1",
           "stringEnums": "true"
         }
+      },
+      "rust": {
+        "generatorName": "rust",
+        "output": "./rust-service",
+        "inputSpec": "./mocks/swagger.json",
+        "enablePostProcessFile": true,
+        "removeOperationIdPrefix": true,
+        "additionalProperties": {
+          "packageVersion": "0.0.1"
+        }
       }
     }
   }

--- a/openapitools.json
+++ b/openapitools.json
@@ -99,8 +99,7 @@
         "removeOperationIdPrefix": true,
         "additionalProperties": {
           "packageVersion": "0.0.1",
-          "library": "reqwest-trait",
-          "mockall": "true"
+          "library": "reqwest"
         }
       }
     }

--- a/openapitools.json
+++ b/openapitools.json
@@ -98,7 +98,9 @@
         "enablePostProcessFile": true,
         "removeOperationIdPrefix": true,
         "additionalProperties": {
-          "packageVersion": "0.0.1"
+          "packageVersion": "0.0.1",
+          "library": "reqwest-trait",
+          "mockall": true
         }
       }
     }

--- a/openapitools.json
+++ b/openapitools.json
@@ -100,7 +100,7 @@
         "additionalProperties": {
           "packageVersion": "0.0.1",
           "library": "reqwest-trait",
-          "mockall": true
+          "mockall": "true"
         }
       }
     }

--- a/pkg/cmd/generate/generate_packages.go
+++ b/pkg/cmd/generate/generate_packages.go
@@ -13,6 +13,7 @@ import (
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator/java"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator/javascript"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator/python"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator/rust"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator/typescript"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/utils"
 	"github.com/spring-financial-group/mqa-helpers/pkg/cobras/helper"
@@ -133,6 +134,7 @@ func (o *PackageOptions) InitialiseGenerators() error {
 	}
 
 	o.languageGenerators = map[string]domain.PackageGenerator{
+		domain.Rust:       rust.NewGenerator(baseGenerator),
 		domain.CSharp:     csharp.NewGenerator(baseGenerator),
 		domain.Java:       java.NewGenerator(baseGenerator),
 		domain.Angular:    angular.NewGenerator(baseGenerator),
@@ -141,6 +143,7 @@ func (o *PackageOptions) InitialiseGenerators() error {
 		domain.Typescript: typescript.NewGenerator(baseGenerator),
 		domain.Go:         _go.NewGenerator(baseGenerator),
 	}
+
 	return nil
 }
 

--- a/pkg/domain/generators.go
+++ b/pkg/domain/generators.go
@@ -10,6 +10,7 @@ const (
 	Javascript = "javascript"
 	Typescript = "typescript"
 	Go         = "go"
+	Rust       = "rust"
 )
 
 type PackageGenerator interface {

--- a/pkg/packageGenerator/rust/generator.go
+++ b/pkg/packageGenerator/rust/generator.go
@@ -1,37 +1,80 @@
 package rust
 
 import (
+	"context"
+	"fmt"
+	"os"
 	"path/filepath"
+	"strings"
 
+	gh "github.com/google/go-github/v47/github"
+	"github.com/pkg/errors"
+	"github.com/sirupsen/logrus"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/domain"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/git"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator"
-	"github.com/spring-financial-group/mqa-logging/pkg/log"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/scmClient/github"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/utils"
 )
 
 const (
-	packagingFilesDir = "/templates/rust"
+	PushRepositoryURL  = "https://github.com/spring-financial-group/mqube-rust-packages.git"
+	PushRepositoryName = "mqube-rust-packages"
+	updateBotLabel     = "updatebot"
 )
 
 type Generator struct {
 	*packageGenerator.BaseGenerator
+	Git domain.Gitter
+	Scm domain.ScmClient
 }
 
 func NewGenerator(baseGenerator *packageGenerator.BaseGenerator) *Generator {
 	return &Generator{
 		BaseGenerator: baseGenerator,
+		Git:           git.NewClient(),
+		Scm:           github.NewClient(baseGenerator.RepoOwner, PushRepositoryName, baseGenerator.GitToken),
 	}
 }
 
 func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 	g.setDynamicConfigVariables()
 
-	packageDir, err := g.BaseGenerator.GeneratePackage(filepath.Join(outputDir, g.GetPackageName()), domain.Rust)
+	repoDir, err := g.Git.Clone(outputDir, PushRepositoryURL)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to clone packages repository")
+	}
+
+	branchName := fmt.Sprintf("update/%s/%s", g.GetPackageName(), g.Version)
+	err = g.Git.CheckoutBranch(repoDir, branchName)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to checkout branch")
+	}
+
+	packageDir := filepath.Join(repoDir, g.GetPackageName())
+	err = g.createFreshDir(packageDir)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to create fresh package dir")
+	}
+
+	_, err = g.BaseGenerator.GeneratePackage(packageDir, domain.Rust)
 	if err != nil {
 		return "", err
 	}
 
-	if err = g.FileIO.TemplateFilesInDir(packagingFilesDir, packageDir, g); err != nil {
-		return "", err
+	err = g.FileIO.Write(filepath.Join(packageDir, "VERSION"), []byte(g.Version), 0700)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to write VERSION file")
+	}
+
+	err = g.Git.AddFiles(repoDir, packageDir)
+	if err != nil {
+		return "", errors.Wrap(err, "failed to add files to Git")
+	}
+
+	err = g.Git.Commit(repoDir, fmt.Sprintf("chore(deps): upgrade %s module -> %s", g.GetPackageName(), g.Version))
+	if err != nil {
+		return "", errors.Wrap(err, "failed to commit package")
 	}
 
 	return packageDir, nil
@@ -47,7 +90,66 @@ func (g *Generator) GetPackageName() string {
 }
 
 func (g *Generator) PushPackage(packageDir string) error {
-	out, err := g.Cmd.Execute(packageDir, "cargo", "publish", "--no-verify", "--allow-dirty")
-	log.Logger().Info(out)
-	return err
+	currentBranch, err := g.Git.GetCurrentBranch(packageDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to get current branch")
+	}
+
+	err = g.Git.Push(packageDir, currentBranch)
+	if err != nil {
+		return errors.Wrap(err, "failed to Git push package")
+	}
+
+	defaultBranch, err := g.Git.GetDefaultBranchName(packageDir)
+	if err != nil {
+		return errors.Wrap(err, "failed to get default branch name")
+	}
+
+	err = g.createPullRequest(currentBranch, defaultBranch)
+	if err != nil {
+		return errors.Wrap(err, "failed to create pull request")
+	}
+	return nil
+}
+
+func (g *Generator) createFreshDir(packageDir string) error {
+	// Check if directory exists
+	if _, err := os.Stat(packageDir); err == nil {
+		// Remove entire directory and its contents
+		if err := os.RemoveAll(packageDir); err != nil {
+			return errors.Wrapf(err, "failed to remove existing directory: %s", packageDir)
+		}
+		logrus.Infof("Removed existing directory: %s", packageDir)
+	}
+
+	// Create a fresh directory
+	if err := os.MkdirAll(packageDir, 0755); err != nil {
+		return errors.Wrapf(err, "failed to create directory: %s", packageDir)
+	}
+	fmt.Println("Created directory:", packageDir)
+
+	return nil
+}
+
+func (g *Generator) createPullRequest(currentBranch, defaultBranch string) error {
+	pr, err := g.Scm.CreatePullRequest(
+		context.Background(),
+		&gh.NewPullRequest{
+			Title:               utils.NewPtr(fmt.Sprintf("chore(deps): upgrade %s package -> %s", g.GetPackageName(), g.Version)),
+			Head:                &currentBranch,
+			Base:                utils.NewPtr(strings.TrimPrefix(defaultBranch, "origin/")),
+			Body:                utils.NewPtr(fmt.Sprintf("Automated rust package update for %s", g.GetPackageName())),
+			MaintainerCanModify: utils.NewPtr(true),
+		},
+	)
+	if err != nil {
+		return errors.Wrap(err, "failed to create pull request")
+	}
+
+	// auto-merge labels
+	_, err = g.Scm.AddLabels(context.Background(), []string{updateBotLabel}, pr.GetNumber())
+	if err != nil {
+		return errors.Wrap(err, "failed to add labels pull request")
+	}
+	return nil
 }

--- a/pkg/packageGenerator/rust/generator.go
+++ b/pkg/packageGenerator/rust/generator.go
@@ -1,10 +1,11 @@
 package rust
 
 import (
-	"fmt"
+	"path/filepath"
+
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/domain"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator"
-	"path/filepath"
+	"github.com/spring-financial-group/mqa-logging/pkg/log"
 )
 
 const (
@@ -37,11 +38,12 @@ func (g *Generator) GeneratePackage(outputDir string) (string, error) {
 }
 
 func (g *Generator) setDynamicConfigVariables() {
-	//g.Cfg.GeneratorCLI.Generators[domain.Rust].AdditionalProperties["packageName"] = g.GetPackageName()
+	g.Cfg.GeneratorCLI.Generators[domain.Rust].AdditionalProperties["packageName"] = g.GetPackageName()
+	g.Cfg.GeneratorCLI.Generators[domain.Rust].AdditionalProperties["packageVersion"] = g.Version
 }
 
 func (g *Generator) GetPackageName() string {
-	return fmt.Sprintf("mqube-%s-%s", g.ServiceName, g.PackageName)
+	return g.RepoName
 }
 
 func (g *Generator) PushPackage(packageDir string) error {

--- a/pkg/packageGenerator/rust/generator.go
+++ b/pkg/packageGenerator/rust/generator.go
@@ -47,7 +47,7 @@ func (g *Generator) GetPackageName() string {
 }
 
 func (g *Generator) PushPackage(packageDir string) error {
-	//solutionPath := fmt.Sprintf("./src/%s/bin/Release/**/*.nupkg", g.GetPackageName())
-	//return g.Cmd.ExecuteAndLog(packageDir, "dotnet", "nuget", "push", solutionPath, "-s", "mqube.packages", "--skip-duplicate")
-	return nil
+	out, err := g.Cmd.Execute(packageDir, "cargo", "publish", "--no-verify", "--allow-dirty")
+	log.Logger().Info(out)
+	return err
 }

--- a/pkg/packageGenerator/rust/generator.go
+++ b/pkg/packageGenerator/rust/generator.go
@@ -1,0 +1,51 @@
+package rust
+
+import (
+	"fmt"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/domain"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator"
+	"path/filepath"
+)
+
+const (
+	packagingFilesDir = "/templates/rust"
+)
+
+type Generator struct {
+	*packageGenerator.BaseGenerator
+}
+
+func NewGenerator(baseGenerator *packageGenerator.BaseGenerator) *Generator {
+	return &Generator{
+		BaseGenerator: baseGenerator,
+	}
+}
+
+func (g *Generator) GeneratePackage(outputDir string) (string, error) {
+	g.setDynamicConfigVariables()
+
+	packageDir, err := g.BaseGenerator.GeneratePackage(filepath.Join(outputDir, g.GetPackageName()), domain.Rust)
+	if err != nil {
+		return "", err
+	}
+
+	if err = g.FileIO.TemplateFilesInDir(packagingFilesDir, packageDir, g); err != nil {
+		return "", err
+	}
+
+	return packageDir, nil
+}
+
+func (g *Generator) setDynamicConfigVariables() {
+	//g.Cfg.GeneratorCLI.Generators[domain.Rust].AdditionalProperties["packageName"] = g.GetPackageName()
+}
+
+func (g *Generator) GetPackageName() string {
+	return fmt.Sprintf("mqube-%s-%s", g.ServiceName, g.PackageName)
+}
+
+func (g *Generator) PushPackage(packageDir string) error {
+	//solutionPath := fmt.Sprintf("./src/%s/bin/Release/**/*.nupkg", g.GetPackageName())
+	//return g.Cmd.ExecuteAndLog(packageDir, "dotnet", "nuget", "push", solutionPath, "-s", "mqube.packages", "--skip-duplicate")
+	return nil
+}

--- a/templates/rust/temp
+++ b/templates/rust/temp
@@ -1,0 +1,1 @@
+I think something needs to live in here

--- a/templates/rust/temp
+++ b/templates/rust/temp
@@ -1,1 +1,0 @@
-I think something needs to live in here


### PR DESCRIPTION
### Changes
- Adds rust package generation
- Fixed some linting issues with file and go usecases

### Context
We need this for new rusty projects.

This uses a very similar approach to the go services, where we can import from a git repo.

Will be able to import packages via the following (using tags as versions):
```toml
[dependencies]
mqube-test-service = { git = "https://github.com/spring-financial-group/mqube-rust-packages.git", tag = "mqube-test-service/0.0.1" }
```

This works, although in the future, a better solution would be to use a fully featured crates registry using smth like azure artifacts