### PR TITLE
fix: rust package gen & oapi-gen version bump

### DIFF
--- a/.lighthouse/jenkins-x/generate-test-packages.yaml
+++ b/.lighthouse/jenkins-x/generate-test-packages.yaml
@@ -57,7 +57,7 @@ spec:
                 #!/bin/bash
                 source /workspace/source/.jx/variables.sh
                 cd ./mocks
-                ./jx3-openapi-generation generate packages go python angular csharp java typescript
+                ./jx3-openapi-generation generate packages go python angular csharp java typescript rust
   podTemplate: {}
   serviceAccountName: tekton-bot
   timeout: 1h0m0s

--- a/openapitools.json
+++ b/openapitools.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.1.0",
+    "version": "7.15.0",
     "generators": {
       "csharp": {
         "output": "./csharp-service",
@@ -99,7 +99,11 @@
         "removeOperationIdPrefix": true,
         "additionalProperties": {
           "packageVersion": "0.0.1",
-          "library": "reqwest"
+          "library": "reqwest-trait",
+          "supportMiddleware": "true",
+          "stringEnums": "true",
+          "mockall": "true",
+          "topLevelApiClient": "true"
         }
       }
     }

--- a/openapitools.json
+++ b/openapitools.json
@@ -101,7 +101,6 @@
           "packageVersion": "0.0.1",
           "library": "reqwest-trait",
           "supportMiddleware": "true",
-          "stringEnums": "true",
           "mockall": "true",
           "topLevelApiClient": "true"
         }


### PR DESCRIPTION
### Changes
- Updates openapi generator cli to v7.15.0
- Use the trait version of rust's reqwest library
- Enable mockall, Api client and middleware rust options

### Context
Using traits (via `reqwest-traits`), middleware and mockall would enable a lot nicer usage of the client packages in rust.

These options were added in the v7.10 update to openapi gen which is the reason behind the version bump.