### PR TITLE
fix: split configs up individually

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -36,6 +36,9 @@ ENV PATH "$PATH:/jx3-openapi-generation"
 # Copy packaging templates
 COPY ./templates /templates
 
+# Copy individual language configuration files
+COPY ./configs /configs
+
 # Add pipeline scripts & config files
 ADD openapitools.json openapitools.json
 ADD CreateAngularPackageV2.sh CreateAngularPackageV2.sh

--- a/configs/angular-openapitools.json
+++ b/configs/angular-openapitools.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "angular": {
+        "output": "./angular-service",
+        "inputSpec": "./mocks/swagger.json",
+        "generatorName": "typescript-angular",
+        "enablePostProcessFile": true,
+        "removeOperationIdPrefix": true,
+        "additionalProperties": {
+          "fileNaming": "camelCase",
+          "ngVersion": "10.0.0",
+          "stringEnums": "true",
+          "generateAliasAsModel": "true"
+        }
+      }
+    }
+  }
+}

--- a/configs/csharp-openapitools.json
+++ b/configs/csharp-openapitools.json
@@ -1,0 +1,22 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.1.0",
+    "generators": {
+      "csharp": {
+        "output": "./csharp-service",
+        "inputSpec": "./mocks/swagger.json",
+        "generatorName": "csharp",
+        "additionalProperties": {
+          "targetFramework": "netstandard2.1",
+          "netCoreProjectFile": "true",
+          "optionalEmitDefaultValues": "true",
+          "validatable": "false",
+          "library": "restsharp",
+          "equatable": "true"
+        }
+      }
+    }
+  }
+}

--- a/configs/go-openapitools.json
+++ b/configs/go-openapitools.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "go": {
+        "output": "./go-service",
+        "inputSpec": "./mocks/swagger.json",
+        "generatorName": "go",
+        "additionalProperties": {
+          "isGoSubmodule": "true"
+        },
+        "globalProperty": {
+          "models": "",
+          "modelTests": "false",
+          "modelDocs": "false",
+          "supportingFiles": "go.mod,go.sum"
+        }
+      }
+    }
+  }
+}

--- a/configs/java-openapitools.json
+++ b/configs/java-openapitools.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "java": {
+        "output": "./java-service",
+        "inputSpec": "./mocks/swagger.json",
+        "generatorName": "java",
+        "additionalProperties": {
+          "dateLibrary": "java8-localdatetime"
+        },
+        "globalProperty": {
+          "models": "",
+          "supportingFiles": "JSON.java",
+          "modelTests": "false",
+          "modelDocs": "false"
+        }
+      }
+    }
+  }
+}

--- a/configs/javascript-openapitools.json
+++ b/configs/javascript-openapitools.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "javascript": {
+        "generatorName": "javascript",
+        "output": "./javascript-service",
+        "inputSpec": "./mocks/swagger.json",
+        "enablePostProcessFile": true,
+        "removeOperationIdPrefix": true,
+        "additionalProperties": {
+          "fileNaming": "camelCase",
+          "packageVersion": "0.0.1",
+          "stringEnums": "true"
+        }
+      }
+    }
+  }
+}

--- a/configs/python-openapitools.json
+++ b/configs/python-openapitools.json
@@ -1,0 +1,19 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "python": {
+        "output": "./python-service",
+        "inputSpec": "./mocks/swagger.json",
+        "generatorName": "python",
+        "additionalProperties": {
+          "library": "asyncio",
+          "generateSourceCodeOnly": "true"
+        },
+        "globalProperty": {}
+      }
+    }
+  }
+}

--- a/configs/rust-openapitools.json
+++ b/configs/rust-openapitools.json
@@ -1,0 +1,23 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "rust": {
+        "generatorName": "rust",
+        "output": "./rust-service",
+        "inputSpec": "./mocks/swagger.json",
+        "enablePostProcessFile": true,
+        "removeOperationIdPrefix": true,
+        "additionalProperties": {
+          "packageVersion": "0.0.1",
+          "library": "reqwest-trait",
+          "supportMiddleware": "true",
+          "mockall": "true",
+          "topLevelApiClient": "true"
+        }
+      }
+    }
+  }
+}

--- a/configs/typescript-openapitools.json
+++ b/configs/typescript-openapitools.json
@@ -1,0 +1,21 @@
+{
+  "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
+  "spaces": 2,
+  "generator-cli": {
+    "version": "7.15.0",
+    "generators": {
+      "typescript": {
+        "generatorName": "typescript",
+        "output": "./typescript-service",
+        "inputSpec": "./mocks/swagger.json",
+        "enablePostProcessFile": true,
+        "removeOperationIdPrefix": true,
+        "additionalProperties": {
+          "fileNaming": "camelCase",
+          "packageVersion": "0.0.1",
+          "stringEnums": "true"
+        }
+      }
+    }
+  }
+}

--- a/pkg/openapitools/config.go
+++ b/pkg/openapitools/config.go
@@ -2,14 +2,16 @@ package openapitools
 
 import (
 	"encoding/json"
-	"github.com/pkg/errors"
-	"github.com/spring-financial-group/jx3-openapi-generation/pkg/utils"
 	"os"
 	"path/filepath"
+
+	"github.com/pkg/errors"
+	"github.com/spring-financial-group/jx3-openapi-generation/pkg/utils"
 )
 
 const (
 	OpenAPIConfigFileName = "openapitools.json"
+	ConfigsDir            = "/configs"
 )
 
 var (
@@ -51,6 +53,16 @@ func GetConfig() (*Config, error) {
 	_, err = cfg.WriteToCurrentWorkingDirectory()
 	if err != nil {
 		return nil, errors.Wrap(err, "failed to write config to file")
+	}
+	return cfg, nil
+}
+
+func GetConfigForLanguage(language string) (*Config, error) {
+	cfg := new(Config)
+	configPath := filepath.Join(ConfigsDir, language+"-"+OpenAPIConfigFileName)
+	err := cfg.readFromFile(configPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to read config from %s", configPath)
 	}
 	return cfg, nil
 }

--- a/pkg/packageGenerator/base_generator.go
+++ b/pkg/packageGenerator/base_generator.go
@@ -60,7 +60,20 @@ func (g *BaseGenerator) GeneratePackage(outputDir, language string) (string, err
 		return "", err
 	}
 
-	g.Cfg.GeneratorCLI.Generators[language].Output = outputDir
+	// Find the generator config for this language
+	var generator *openapitools.Generator
+	for key, gen := range g.Cfg.GeneratorCLI.Generators {
+		if key == language {
+			generator = gen
+			break
+		}
+	}
+
+	if generator == nil {
+		return "", errors.New("generator configuration not found for language: " + language)
+	}
+
+	generator.Output = outputDir
 	cfgPath, err := g.Cfg.WriteToCurrentWorkingDirectory()
 	if err != nil {
 		return "", err

--- a/pkg/packageGenerator/csharp/generator.go
+++ b/pkg/packageGenerator/csharp/generator.go
@@ -2,10 +2,11 @@ package csharp
 
 import (
 	"fmt"
+	"path/filepath"
+
 	"github.com/pkg/errors"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/domain"
 	"github.com/spring-financial-group/jx3-openapi-generation/pkg/packageGenerator"
-	"path/filepath"
 )
 
 const (

--- a/pkg/packageGenerator/javascript/generator.go
+++ b/pkg/packageGenerator/javascript/generator.go
@@ -1,4 +1,4 @@
-package javscript
+package javascript
 
 import (
 	"fmt"


### PR DESCRIPTION
### Changes
- split language configs into own openapi generator config files
- pin c# openapi-generator version to 7.1.0
- fix `javscript` -> `javascript`

### Context
Been having issues with the c# generation in our services on the newest version however we need the latest version for rust package generation, so splitting the config per-language makes sense.

One issue is to do with the naming of 'Parameter' in the shepherd package clashing with 'Parameter' in RestSharp in the newer version of openapi-generator - causing the failing builds on Friday.