### PR TITLE
chore: rollback csharp to 7.1.0

### DIFF
--- a/configs/csharp-openapitools.json
+++ b/configs/csharp-openapitools.json
@@ -2,7 +2,7 @@
   "$schema": "node_modules/@openapitools/openapi-generator-cli/config.schema.json",
   "spaces": 2,
   "generator-cli": {
-    "version": "7.15.0",
+    "version": "7.1.0",
     "generators": {
       "csharp": {
         "output": "./csharp-service",


### PR DESCRIPTION
7.15.0 doesn't work well with our microservices due to ambiguous imports. We can look into fixing this Friday, but this is currently blocking a lot of changes from being made