### PR TITLE
chore: add pipeline linter to lighthouse configuration

### DIFF
--- a/.lighthouse/jenkins-x/lint-pipelines.yaml
+++ b/.lighthouse/jenkins-x/lint-pipelines.yaml
@@ -1,0 +1,30 @@
+apiVersion: tekton.dev/v1beta1
+kind: PipelineRun
+metadata:
+    name: lint-pipelines
+spec:
+    pipelineSpec:
+        tasks:
+        - name: from-build-pack
+          resources: {}
+          taskSpec:
+              metadata: {}
+              stepTemplate:
+                  image: uses:jenkins-x/jx3-pipeline-catalog/tasks/go/pullrequest.yaml@versionStream
+                  name: ""
+                  resources:
+                      limits: {}
+                  workingDir: /workspace/source
+              steps:
+              - image: uses:jenkins-x/jx3-pipeline-catalog/tasks/git-clone/git-clone-pr.yaml@versionStream
+                name: ""
+                resources: {}
+              - name: jx-variables
+                resources: {}
+              - image: uses:spring-financial-group/mqube-pipeline-catalog/tasks/tools/jx-pipeline-linter.yaml@main
+                name: ""
+                resources: {}
+    podTemplate: {}
+    serviceAccountName: tekton-bot
+    timeout: 1h0m0s
+status: {}

--- a/.lighthouse/jenkins-x/triggers.yaml
+++ b/.lighthouse/jenkins-x/triggers.yaml
@@ -27,6 +27,13 @@ spec:
     always_run: true
     optional: false
     source: "generate-test-packages.yaml"
+  - name: lint-pipelines
+    context: "lint-pipelines"
+    run_if_changed: '.lighthouse\/jenkins-x\/.*'
+    optional: false
+    trigger: (?m)^/test( all| lint-pipelines.*),?(s+|$)
+    rerun_command: /test lint-pipelines
+    source: "lint-pipelines.yaml"
   postsubmits:
   - name: release
     context: "release"


### PR DESCRIPTION
### Changes
* Add `lint-pipelines` pipeline, using `jx-pipeline-linter.yaml` from `mqube-pipeline-catalog`

### Context

This PR adds pipeline linter to CI, based on [jx-pipeline lint](https://jayex.io/v3/develop/reference/jx/pipeline/lint/)

The pipeline runs whenever files within `.lighhouse/jenkins-x` are modified in a PR, ensuring it only runs when needed