### PR TITLE
feat(go): prefix all enums with the class name

### DIFF
--- a/configs/go-openapitools.json
+++ b/configs/go-openapitools.json
@@ -9,7 +9,8 @@
         "inputSpec": "./mocks/swagger.json",
         "generatorName": "go",
         "additionalProperties": {
-          "isGoSubmodule": "true"
+          "isGoSubmodule": "true",
+          "enumClassPrefix": "true"
         },
         "globalProperty": {
           "models": "",


### PR DESCRIPTION
### Changes
* Go: create all enums prefixed with the class name

### Context
This seems to be default behavour if there are clashing enums.

Just seen enum names revert back to non-prefixed when the clash is removed which is annoying (https://github.com/spring-financial-group/mqube-go-packages/pull/4721/changes).

I think I prefer this naming as it makes it easier to find things in the ide auto complete we should just stick with one to stop this from happening again.
