### PR TITLE
fix(python): make mqube-schemas a minor version bump

### DIFF
--- a/pipeline/generate-python-package.yaml
+++ b/pipeline/generate-python-package.yaml
@@ -105,9 +105,9 @@ spec:
         HEREDOC
 
         git add "$serviceName"/schemas.py "$serviceName"/__init__.py "$serviceName"/schemas_v2.py
-        git commit -m "chore(deps): upgrade $serviceName package -> v$VERSION"
+        git commit -m "feat(deps): upgrade $serviceName package -> v$VERSION"
         git push --set-upstream origin "$branch"
-        gh pr create --title "chore(deps): upgrade $serviceName package -> v$VERSION" --body "Automated python schemas update for $serviceName" --reviewer Reton2 --base master --head "$branch" -l updatebot
+        gh pr create --title "feat(deps): upgrade $serviceName package -> v$VERSION" --body "Automated python schemas update for $serviceName" --reviewer Reton2 --base master --head "$branch" -l updatebot
 
         rm /workspace/source/gittoken.gt
       workingDir: /workspace/source

--- a/pkg/packagegenerator/python/generator.go
+++ b/pkg/packagegenerator/python/generator.go
@@ -123,7 +123,7 @@ func (g *Generator) GenerateSchemasPackage(outputDir string) (string, error) {
 		return "", errors.Wrap(err, "failed to add package to Git")
 	}
 
-	err = g.Git.Commit(repoDir, fmt.Sprintf("chore(deps): upgrade %s package -> %s", g.GetPackageName(), g.Version))
+	err = g.Git.Commit(repoDir, fmt.Sprintf("feat(deps): upgrade %s package -> %s", g.GetPackageName(), g.Version))
 	if err != nil {
 		return "", errors.Wrap(err, "failed to commit package")
 	}
@@ -209,7 +209,7 @@ func (g *Generator) createPullRequest(currentBranch, defaultBranch string) error
 	pr, err := g.Scm.CreatePullRequest(
 		context.Background(),
 		&gh.NewPullRequest{
-			Title:               utils.NewPtr(fmt.Sprintf("chore(deps): upgrade %s package -> %s", g.GetPackageName(), g.Version)),
+			Title:               utils.NewPtr(fmt.Sprintf("feat(deps): upgrade %s package -> %s", g.GetPackageName(), g.Version)),
 			Head:                &currentBranch,
 			Base:                utils.NewPtr(strings.TrimPrefix(defaultBranch, "origin/")),
 			Body:                utils.NewPtr(fmt.Sprintf("Automated python schemas update for %s", g.GetPackageName())),


### PR DESCRIPTION
### Changes
* Change commit message for python promotion chore -> feat

### Context
Python services aren't getting renovate PRs for mqube-schemas cos every update is just creating a chore (patch) in mqube-schemas, renovate only updates on feat (minor).

<img width="941" height="965" alt="image" src="https://github.com/user-attachments/assets/42f32995-aebb-47cd-b58a-99b86df651cd" />

