### PR TITLE
feat: pass server variables to generate command

### DIFF
--- a/pkg/cmd/generate/generate.go
+++ b/pkg/cmd/generate/generate.go
@@ -30,6 +30,7 @@ type Options struct {
 	GitUser            string
 	GitToken           string
 	SkipPush           bool
+	ServerVariables    string
 
 	FileIO      domain.FileIO
 	PackageName string
@@ -41,6 +42,7 @@ const (
 	repoOwnerKey          = "REPO_OWNER"
 	repoNameKey           = "REPO_NAME"
 	swaggerServiceNameKey = "SwaggerServiceName"
+	serverVariables       = "ServerVariables"
 	specPathKey           = "SpecPath"
 	gitUserKey            = "GIT_USER"
 	gitTokenKey           = "GIT_TOKEN"
@@ -139,6 +141,7 @@ func (o *Options) getVariablesFromEnvironment() error {
 	if o.GitToken = os.Getenv(gitTokenKey); o.GitToken == "" {
 		missingVariables = append(missingVariables, gitTokenKey)
 	}
+	o.ServerVariables = os.Getenv(serverVariables)
 	// Check if SKIP_PUSH is set to "true"
 	if skipPush := os.Getenv(skipPushKey); skipPush == "true" {
 		o.SkipPush = true

--- a/pkg/cmd/generate/generate_packages.go
+++ b/pkg/cmd/generate/generate_packages.go
@@ -137,7 +137,7 @@ func (o *PackageOptions) InitialiseGenerators() error {
 			return errors.Wrapf(err, "failed to get config for language %s", language)
 		}
 
-		baseGenerator, err := packagegenerator.NewBaseGenerator(o.Version, o.SwaggerServiceName, o.RepoOwner, o.RepoName, o.GitToken, o.GitUser, o.SpecPath, o.PackageName, config)
+		baseGenerator, err := packagegenerator.NewBaseGenerator(o.Version, o.SwaggerServiceName, o.RepoOwner, o.RepoName, o.GitToken, o.GitUser, o.SpecPath, o.PackageName, o.ServerVariables, config)
 		if err != nil {
 			return errors.Wrapf(err, "failed to create base generator for %s", language)
 		}

--- a/pkg/packagegenerator/base_generator.go
+++ b/pkg/packagegenerator/base_generator.go
@@ -9,33 +9,35 @@ import (
 )
 
 type BaseGenerator struct {
-	Version     string
-	ServiceName string
-	RepoOwner   string
-	RepoName    string
-	GitToken    string
-	GitUser     string
-	SpecPath    string
-	PackageName string
+	Version         string
+	ServiceName     string
+	RepoOwner       string
+	RepoName        string
+	GitToken        string
+	GitUser         string
+	SpecPath        string
+	PackageName     string
+	ServerVariables string
 
 	Cfg    *openapitools.Config
 	Cmd    domain.CommandRunner
 	FileIO domain.FileIO
 }
 
-func NewBaseGenerator(version, serviceName, repoOwner, repoName, gitToken, gitUser, specPath string, packageName string, cfg *openapitools.Config) (*BaseGenerator, error) {
+func NewBaseGenerator(version, serviceName, repoOwner, repoName, gitToken, gitUser, specPath, packageName, serverVariables string, cfg *openapitools.Config) (*BaseGenerator, error) {
 	gen := &BaseGenerator{
-		Version:     version,
-		ServiceName: serviceName,
-		RepoOwner:   repoOwner,
-		RepoName:    repoName,
-		GitUser:     gitUser,
-		GitToken:    gitToken,
-		SpecPath:    specPath,
-		PackageName: packageName,
-		Cmd:         commandrunner.NewCommandRunner(),
-		FileIO:      file.NewFileIO(),
-		Cfg:         cfg,
+		Version:         version,
+		ServiceName:     serviceName,
+		RepoOwner:       repoOwner,
+		RepoName:        repoName,
+		GitUser:         gitUser,
+		GitToken:        gitToken,
+		SpecPath:        specPath,
+		PackageName:     packageName,
+		ServerVariables: serverVariables,
+		Cmd:             commandrunner.NewCommandRunner(),
+		FileIO:          file.NewFileIO(),
+		Cfg:             cfg,
 	}
 
 	// Set dynamic config variables
@@ -78,7 +80,15 @@ func (g *BaseGenerator) GeneratePackage(outputDir, language string) (string, err
 	defer g.FileIO.DeferRemove(cfgPath)
 
 	// Generate Package
-	err = g.Cmd.ExecuteAndLog("", "npx", "@openapitools/openapi-generator-cli", "generate", "--generator-key", language, "--config", cfgPath)
+
+	args := []string{"@openapitools/openapi-generator-cli", "generate", "--generator-key", language, "--config", cfgPath}
+
+	if g.ServerVariables != "" {
+		args = append(args, "--server-variables="+g.ServerVariables)
+	}
+
+	// Generate Package
+	err = g.Cmd.ExecuteAndLog("", "npx", args...)
 	if err != nil {
 		return "", errors.Wrap(err, "failed to generate package")
 	}

--- a/pkg/packagegenerator/java/generator_test.go
+++ b/pkg/packagegenerator/java/generator_test.go
@@ -115,6 +115,7 @@ func TestJavaGeneratorFixesIssues(t *testing.T) {
 		"test-user",
 		specFile,
 		"TestClient",
+		"TestService",
 		cfg,
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
### Changes
* Pass server variables to generate command

### Context
These are used in OAS3+ to override variables in the configured servers.