### PR TITLE
chore: add zack, luis & paul to OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -1,4 +1,10 @@
 approvers:
 - infrastructure
+- craggs
+- luisjones
+- ZackJagger
 reviewers:
 - infrastructure
+- craggs
+- luisjones
+- ZackJagger


### PR DESCRIPTION
### Changes
- Update OWNERS to include Zack, Luis & Craggs

### Context
Devs should have some control, but I'd rather it just be a few that have knowledge of the tool itself.